### PR TITLE
Fix BetterTTV emoji blacklist

### DIFF
--- a/BTTVEmoteProvider.cs
+++ b/BTTVEmoteProvider.cs
@@ -99,8 +99,12 @@ namespace MessageHeightTwitch
 				fetchAllForList(channelEmotes.channelEmotes.Union(channelEmotes.sharedEmotes));
 			}
 
-			rawJson = await Client.GetAsync("https://raw.githubusercontent.com/night/betterttv/4f1239b590b914376c035ad7eb37847e553faf3d/src/utils/emoji-blacklist.json", Token);
-			var emojiBlacklist = JsonSerializer.Deserialize<List<string>>(await rawJson.Content.ReadAsStringAsync(), new JsonSerializerOptions() {
+			var rawJs = await Client.GetAsync("https://raw.githubusercontent.com/night/betterttv/master/src/utils/emoji-blacklist.js", Token);
+			rawContents = (await rawJs.Content.ReadAsStringAsync())
+				.Replace("module.exports = ", "")
+				.Replace(";", "")
+				.Replace("'", "\"");
+			var emojiBlacklist = JsonSerializer.Deserialize<List<string>>(rawContents, new JsonSerializerOptions() {
 				ReadCommentHandling = JsonCommentHandling.Skip
 			});
 

--- a/BTTVEmoteProvider.cs
+++ b/BTTVEmoteProvider.cs
@@ -99,7 +99,7 @@ namespace MessageHeightTwitch
 				fetchAllForList(channelEmotes.channelEmotes.Union(channelEmotes.sharedEmotes));
 			}
 
-			rawJson = await Client.GetAsync("https://raw.githubusercontent.com/night/BetterTTV/master/src/utils/emoji-blacklist.json", Token);
+			rawJson = await Client.GetAsync("https://raw.githubusercontent.com/night/betterttv/4f1239b590b914376c035ad7eb37847e553faf3d/src/utils/emoji-blacklist.json", Token);
 			var emojiBlacklist = JsonSerializer.Deserialize<List<string>>(await rawJson.Content.ReadAsStringAsync(), new JsonSerializerOptions() {
 				ReadCommentHandling = JsonCommentHandling.Skip
 			});


### PR DESCRIPTION
`src/utils/emoji-blacklist.json` [was converted to a CommonJS module](https://github.com/night/betterttv/commit/9f628d4428e7f65fcb7867504e78b60a8139aaef) and the library couldn't access the JSON file.

This PR fixes the issue by ~~using the old commit where the JSON file was available~~ trying to convert the JS file to JSON.