### PR TITLE
Update URL to emojis to a tagged one instead of master

### DIFF
--- a/BTTVEmoteProvider.cs
+++ b/BTTVEmoteProvider.cs
@@ -108,7 +108,7 @@ namespace MessageHeightTwitch
 				ReadCommentHandling = JsonCommentHandling.Skip
 			});
 
-			rawJson = await Client.GetAsync("https://raw.githubusercontent.com/muan/emojilib/master/emojis.json", Token);
+			rawJson = await Client.GetAsync("https://raw.githubusercontent.com/muan/emojilib/v2.4.0/emojis.json", Token);
 			var emojis = JsonSerializer.Deserialize<Dictionary<string, EmojilibEmoji>>(await rawJson.Content.ReadAsStringAsync());
 
 			SupportedEmojis = new HashSet<string>(emojis.Select(x => x.Value.@char).Where(x => !emojiBlacklist.Contains(x)));


### PR DESCRIPTION
The muan/emojilib repo is now active and they've changed the emojis.json

this just points it at the old version, but we should probalby move towards using either:
1) local files
2) submodules

so we can do proper versioning of these files and not relying on the repo to stay in the same format
