### PR TITLE
Pin the BetterTTV Emoji Blacklist list

### DIFF
--- a/BTTVEmoteProvider.cs
+++ b/BTTVEmoteProvider.cs
@@ -99,7 +99,7 @@ namespace MessageHeightTwitch
 				fetchAllForList(channelEmotes.channelEmotes.Union(channelEmotes.sharedEmotes));
 			}
 
-			var rawJs = await Client.GetAsync("https://raw.githubusercontent.com/night/betterttv/master/src/utils/emoji-blacklist.js", Token);
+			var rawJs = await Client.GetAsync("https://raw.githubusercontent.com/night/betterttv/9f628d4428e7f65fcb7867504e78b60a8139aaef/src/utils/emoji-blacklist.js", Token);
 			rawContents = (await rawJs.Content.ReadAsStringAsync())
 				.Replace("module.exports = ", "")
 				.Replace(";", "")


### PR DESCRIPTION
Issue first detected in https://github.com/pajbot/pajbot2/issues/403

tl;dr: emoji-blacklist.js in master of betterttv changed (see diff [here](https://github.com/night/betterttv/commit/46c6d0f700c7111af09285338a455c44e564f6dd#diff-e3196c1c3be227749e4bd7d512c79d72986eb328d0f9f19c633a46fc58d559c8R1)), this PR pins the version of emoji-blacklist.js to the one we were accessing 5 days ago