### PR TITLE
Add missing `stdbool.h` header

### DIFF
--- a/c-interop/exports.h
+++ b/c-interop/exports.h
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 typedef struct _TwitchEmote
 {
 	const char *Name;


### PR DESCRIPTION
This fixes pajbot2 compilation

Compilation error log:
```
# github.com/pajbot/pajbot2/pkg/modules/message_height_limit
In file included from ../pkg/modules/message_height_limit/m.go:8:
./../../../3rdParty/MessageHeightTwitch/c-interop/exports.h:10:88: error: unknown type name 'bool'
   10 | typedef int(FxInitChannel2)(const char *Channel, const char* ChannelId, int TimeoutMs, bool Enable7TVEmotes);
      |                                                                                        ^~~~
./../../../3rdParty/MessageHeightTwitch/c-interop/exports.h:24:85: error: unknown type name 'bool'
   24 |  extern int InitChannel2(const char *Channel, const char* ChannelId, int TimeoutMs, bool Enable7TVEmotes);
      |                                                                                     ^~~~
zneix@shungite:/opt/pajbot2$ echo $?
2
zneix@shungite:/opt/pajbot2$
```
