### PR TITLE
Add .editorconfig & run `dotnet format`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*.cs]
+indent_size = 4
+indent_style = tab
+tab_width = 4
+
+csharp_new_line_before_open_brace = accessors, anonymous_methods, anonymous_types, events, indexers, local_functions, methods, object_collection_array_initializers, properties, types
+csharp_new_line_before_else = false
+csharp_new_line_before_catch = false
+csharp_new_line_before_members_in_object_initializers = true
+csharp_preserve_single_line_statements = true

--- a/7TVEmoteProvider.cs
+++ b/7TVEmoteProvider.cs
@@ -23,13 +23,13 @@ namespace MessageHeightTwitch
 						public int width { get; set; }
 						public int height { get; set; }
 					}
-					
+
 					public List<SevenTVEmoticonFile> files { get; set; }
 				}
-				
+
 				public SevenTVEmoticonHost host { get; set; }
 			}
-			
+
 			public string name { get; set; }
 			public int flags { get; set; }
 			public SevenTVEmoticonData data { get; set; }
@@ -39,17 +39,17 @@ namespace MessageHeightTwitch
 		{
 			public List<SevenTVEmoticon> emotes { get; set; }
 		}
-		
+
 		private class SevenTVUserEmotes
 		{
 			internal class SevenTVEmoteSet
 			{
 				public List<SevenTVEmoticon> emotes { get; set; }
 			}
-			
+
 			public SevenTVEmoteSet emote_set { get; set; }
 		}
-		
+
 		public bool TryGetEmote(string Name, out SizeF Size) => EmoteCache.TryGetValue(Name, out Size);
 
 		public async Task Initialize(string ChannelID, CancellationToken Token)

--- a/BTTVEmoteProvider.cs
+++ b/BTTVEmoteProvider.cs
@@ -54,7 +54,7 @@ namespace MessageHeightTwitch
 
 			var rawJson = await Client.GetAsync("https://api.betterttv.net/3/cached/emotes/global", Token);
 			rawJson.EnsureSuccessStatusCode();
-			
+
 			var globalEmotes = await JsonSerializer.DeserializeAsync<IEnumerable<BTTVEmote>>(await rawJson.Content.ReadAsStreamAsync());
 
 			void addToList(string Name, Stream EmoteStream)
@@ -102,7 +102,8 @@ namespace MessageHeightTwitch
 				.Replace("module.exports = ", "")
 				.Replace(";", "")
 				.Replace("'", "\"");
-			var emojiBlacklist = JsonSerializer.Deserialize<List<string>>(rawContents, new JsonSerializerOptions() {
+			var emojiBlacklist = JsonSerializer.Deserialize<List<string>>(rawContents, new JsonSerializerOptions()
+			{
 				ReadCommentHandling = JsonCommentHandling.Skip
 			});
 

--- a/MessageHeightTwitch.cs
+++ b/MessageHeightTwitch.cs
@@ -9,8 +9,8 @@ using SixLabors.ImageSharp;
 
 namespace MessageHeightTwitch
 {
-    public class MessageHeightTwitch
-    {
+	public class MessageHeightTwitch
+	{
 		public struct CharacterProperty
 		{
 			public float Width;
@@ -55,7 +55,7 @@ namespace MessageHeightTwitch
 			}
 
 			CharacterProperties = charProperties.ToArray();
-			
+
 			Debug.Assert(broken);
 			Debug.Assert(CharacterProperties['A'].Width == 8);
 			Debug.Assert(CharacterProperties['@'].Width == 12.171875f);
@@ -317,7 +317,7 @@ namespace MessageHeightTwitch
 
 			var split = Regex.Split(Input, @"(?<=[ -])");
 			int curChar = 0;
-			for (int x = 0;x < split.Length;/* Increment is at the end of the loop */) {
+			for (int x = 0; x < split.Length;/* Increment is at the end of the loop */) {
 				// Currently processing emote name
 				string curEmoteName = null;
 				// Currently processing emote provider
@@ -388,7 +388,7 @@ namespace MessageHeightTwitch
 						// No dice, try to:
 						curEmoteName = split[x].Substring(curChar);
 						emojiMatch = EmojiRegex.Match(curEmoteName);
-						
+
 						//	...limit current lookup to first possible emoji
 						if (emojiMatch.Success)
 							curEmoteName = curEmoteName.Substring(0, emojiMatch.Index);
@@ -551,7 +551,7 @@ namespace MessageHeightTwitch
 				if (split[x].Substring(curChar) != " ")
 					prevEmote = null;
 
-				for (int oldCurChar = curChar;curChar < split[x].Length;curChar++) {
+				for (int oldCurChar = curChar; curChar < split[x].Length; curChar++) {
 					if (emojiMatch.Success && emojiMatch.Index == curChar - oldCurChar) {
 						if (!FFZIsEmojiSupported(split[x].Substring(curChar, emojiMatch.Length)) &&
 							!BTTVIsEmojiSupported(split[x].Substring(curChar, emojiMatch.Length))) {

--- a/MessageHeightTwitchStatic.cs
+++ b/MessageHeightTwitchStatic.cs
@@ -4,7 +4,8 @@ using System.Runtime.InteropServices;
 
 class MessageHeightTwitchStatic
 {
-	public struct TwitchEmote {
+	public struct TwitchEmote
+	{
 		public string Name;
 		public string Url;
 	}
@@ -65,7 +66,7 @@ class MessageHeightTwitchStatic
 		try {
 			var dict = new Dictionary<string, string>();
 			if (TwitchEmotes != null) {
-				for (int x = 0;x < TwitchEmotesLen * Marshal.SizeOf<TwitchEmote>();x += Marshal.SizeOf<TwitchEmote>()) {
+				for (int x = 0; x < TwitchEmotesLen * Marshal.SizeOf<TwitchEmote>(); x += Marshal.SizeOf<TwitchEmote>()) {
 					var te = Marshal.PtrToStructure<TwitchEmote>(new IntPtr(TwitchEmotes.ToInt64() + x));
 					dict.Add(te.Name, te.Url);
 				}


### PR DESCRIPTION
The only contentious addition I made was adding `object_collection_array_initializers` to `csharp_new_line_before_open_brace`.
With it added, one line changed.
Without it, one line changed.
